### PR TITLE
Switch to `alloy`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ categories = ["cryptography::cryptocurrencies"]
 name = "serde_utils"
 
 [dependencies]
+alloy-primitives = { version = "0.7.0", features = ["ssz", "serde"] }
 serde = { version = "1.0.0", features = ["derive"] }
 serde_derive = "1.0.0"
 serde_json = "1.0.0"
 hex = "0.4.3"
-ethereum-types = "0.14.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography::cryptocurrencies"]
 name = "serde_utils"
 
 [dependencies]
-alloy-primitives = { version = "0.7.0", features = ["ssz", "serde"] }
+alloy-primitives = { version = "0.7.7", features = ["serde"] }
 serde = { version = "1.0.0", features = ["derive"] }
 serde_derive = "1.0.0"
 serde_json = "1.0.0"

--- a/src/address_hex.rs
+++ b/src/address_hex.rs
@@ -1,0 +1,34 @@
+use alloy_primitives::Address;
+use serde::de::Error;
+use serde::{Deserializer, Serializer};
+
+use crate::hex::PrefixedHexVisitor;
+
+pub fn serialize<S>(address: &Address, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut hex_string: String = "0x".to_string();
+    hex_string.push_str(&hex::encode(&address));
+
+    serializer.serialize_str(&hex_string)
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Address, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let decoded = deserializer.deserialize_str(PrefixedHexVisitor)?;
+
+    if decoded.len() != 20 {
+        return Err(D::Error::custom(format!(
+            "expected {} bytes for array, got {}",
+            20,
+            decoded.len()
+        )));
+    }
+
+    let mut array = [0; 20];
+    array.copy_from_slice(&decoded);
+    Ok(array.into())
+}

--- a/src/b256_hex.rs
+++ b/src/b256_hex.rs
@@ -1,0 +1,34 @@
+use alloy_primitives::B256;
+use serde::de::Error;
+use serde::{Deserializer, Serializer};
+
+use crate::hex::PrefixedHexVisitor;
+
+pub fn serialize<S>(hash: &B256, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut hex_string: String = "0x".to_string();
+    hex_string.push_str(&hex::encode(&hash));
+
+    serializer.serialize_str(&hex_string)
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<B256, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let decoded = deserializer.deserialize_str(PrefixedHexVisitor)?;
+
+    if decoded.len() != 32 {
+        return Err(D::Error::custom(format!(
+            "expected {} bytes for array, got {}",
+            32,
+            decoded.len()
+        )));
+    }
+
+    let mut array = [0; 32];
+    array.copy_from_slice(&decoded);
+    Ok(array.into())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 mod quoted_int;
 
+pub mod address_hex;
+pub mod b256_hex;
 pub mod fixed_bytes_hex;
 pub mod hex;
 pub mod hex_vec;

--- a/src/quoted_int.rs
+++ b/src/quoted_int.rs
@@ -4,7 +4,7 @@
 //!
 //! Quotes can be optional during decoding.
 
-use ethereum_types::U256;
+use alloy_primitives::U256;
 use serde::{Deserializer, Serializer};
 use serde_derive::{Deserialize, Serialize};
 use std::convert::TryFrom;
@@ -177,7 +177,7 @@ pub mod quoted_u256 {
         where
             E: serde::de::Error,
         {
-            U256::from_dec_str(v).map_err(serde::de::Error::custom)
+            U256::from_str_radix(v, 10).map_err(serde::de::Error::custom)
         }
     }
 
@@ -209,12 +209,12 @@ mod test {
     #[test]
     fn u256_with_quotes() {
         assert_eq!(
-            &serde_json::to_string(&WrappedU256(U256::one())).unwrap(),
+            &serde_json::to_string(&WrappedU256(U256::from(1))).unwrap(),
             "\"1\""
         );
         assert_eq!(
             serde_json::from_str::<WrappedU256>("\"1\"").unwrap(),
-            WrappedU256(U256::one())
+            WrappedU256(U256::from(1))
         );
     }
 

--- a/src/u256_dec.rs
+++ b/src/u256_dec.rs
@@ -1,4 +1,4 @@
-use ethereum_types::U256;
+use alloy_primitives::U256;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 pub fn serialize<S>(num: &U256, serializer: S) -> Result<S::Ok, S::Error>
@@ -13,12 +13,12 @@ where
     D: Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
-    U256::from_dec_str(&s).map_err(|e| de::Error::custom(format!("Invalid U256 string: {e}")))
+    U256::from_str_radix(&s, 10).map_err(|e| de::Error::custom(format!("Invalid U256 string: {e}")))
 }
 
 #[cfg(test)]
 mod test {
-    use ethereum_types::U256;
+    use alloy_primitives::U256;
     use serde::{Deserialize, Serialize};
     use serde_json;
 
@@ -32,37 +32,43 @@ mod test {
     #[test]
     fn encoding() {
         assert_eq!(
-            &serde_json::to_string(&Wrapper { val: 0.into() }).unwrap(),
+            &serde_json::to_string(&Wrapper { val: U256::from(0) }).unwrap(),
             "\"0\""
         );
         assert_eq!(
-            &serde_json::to_string(&Wrapper { val: 1.into() }).unwrap(),
+            &serde_json::to_string(&Wrapper { val: U256::from(1) }).unwrap(),
             "\"1\""
         );
         assert_eq!(
-            &serde_json::to_string(&Wrapper { val: 256.into() }).unwrap(),
+            &serde_json::to_string(&Wrapper {
+                val: U256::from(256)
+            })
+            .unwrap(),
             "\"256\""
         );
         assert_eq!(
-            &serde_json::to_string(&Wrapper { val: 65.into() }).unwrap(),
+            &serde_json::to_string(&Wrapper {
+                val: U256::from(65)
+            })
+            .unwrap(),
             "\"65\""
         );
         assert_eq!(
-            &serde_json::to_string(&Wrapper { val: 1024.into() }).unwrap(),
+            &serde_json::to_string(&Wrapper {
+                val: U256::from(1024)
+            })
+            .unwrap(),
             "\"1024\""
         );
         assert_eq!(
             &serde_json::to_string(&Wrapper {
-                val: U256::max_value() - 1
+                val: U256::MAX - U256::from(1)
             })
             .unwrap(),
             "\"115792089237316195423570985008687907853269984665640564039457584007913129639934\""
         );
         assert_eq!(
-            &serde_json::to_string(&Wrapper {
-                val: U256::max_value()
-            })
-            .unwrap(),
+            &serde_json::to_string(&Wrapper { val: U256::MAX }).unwrap(),
             "\"115792089237316195423570985008687907853269984665640564039457584007913129639935\""
         );
     }
@@ -71,15 +77,19 @@ mod test {
     fn decoding() {
         assert_eq!(
             serde_json::from_str::<Wrapper>("\"0\"").unwrap(),
-            Wrapper { val: 0.into() },
+            Wrapper { val: U256::from(0) },
         );
         assert_eq!(
             serde_json::from_str::<Wrapper>("\"65\"").unwrap(),
-            Wrapper { val: 65.into() },
+            Wrapper {
+                val: U256::from(65)
+            },
         );
         assert_eq!(
             serde_json::from_str::<Wrapper>("\"1024\"").unwrap(),
-            Wrapper { val: 1024.into() },
+            Wrapper {
+                val: U256::from(1024)
+            },
         );
         assert_eq!(
             serde_json::from_str::<Wrapper>(
@@ -87,7 +97,7 @@ mod test {
             )
             .unwrap(),
             Wrapper {
-                val: U256::max_value() - 1
+                val: U256::MAX - U256::from(1)
             },
         );
         assert_eq!(
@@ -96,7 +106,7 @@ mod test {
             )
             .unwrap(),
             Wrapper {
-                val: U256::max_value()
+                val: U256::MAX
             },
         );
         serde_json::from_str::<Wrapper>("\"0x0\"").unwrap_err();

--- a/src/u256_hex_be.rs
+++ b/src/u256_hex_be.rs
@@ -1,5 +1,4 @@
-use ethereum_types::U256;
-
+use alloy_primitives::U256;
 use serde::de::Visitor;
 use serde::{de, Deserializer, Serialize, Serializer};
 use std::fmt;
@@ -55,7 +54,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use ethereum_types::U256;
+    use alloy_primitives::U256;
     use serde::{Deserialize, Serialize};
     use serde_json;
 
@@ -69,37 +68,43 @@ mod test {
     #[test]
     fn encoding() {
         assert_eq!(
-            &serde_json::to_string(&Wrapper { val: 0.into() }).unwrap(),
+            &serde_json::to_string(&Wrapper { val: U256::from(0) }).unwrap(),
             "\"0x0\""
         );
         assert_eq!(
-            &serde_json::to_string(&Wrapper { val: 1.into() }).unwrap(),
+            &serde_json::to_string(&Wrapper { val: U256::from(1) }).unwrap(),
             "\"0x1\""
         );
         assert_eq!(
-            &serde_json::to_string(&Wrapper { val: 256.into() }).unwrap(),
+            &serde_json::to_string(&Wrapper {
+                val: U256::from(256)
+            })
+            .unwrap(),
             "\"0x100\""
         );
         assert_eq!(
-            &serde_json::to_string(&Wrapper { val: 65.into() }).unwrap(),
+            &serde_json::to_string(&Wrapper {
+                val: U256::from(65)
+            })
+            .unwrap(),
             "\"0x41\""
         );
         assert_eq!(
-            &serde_json::to_string(&Wrapper { val: 1024.into() }).unwrap(),
+            &serde_json::to_string(&Wrapper {
+                val: U256::from(1024)
+            })
+            .unwrap(),
             "\"0x400\""
         );
         assert_eq!(
             &serde_json::to_string(&Wrapper {
-                val: U256::max_value() - 1
+                val: U256::MAX - U256::from(1)
             })
             .unwrap(),
             "\"0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe\""
         );
         assert_eq!(
-            &serde_json::to_string(&Wrapper {
-                val: U256::max_value()
-            })
-            .unwrap(),
+            &serde_json::to_string(&Wrapper { val: U256::MAX }).unwrap(),
             "\"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\""
         );
     }
@@ -108,15 +113,19 @@ mod test {
     fn decoding() {
         assert_eq!(
             serde_json::from_str::<Wrapper>("\"0x0\"").unwrap(),
-            Wrapper { val: 0.into() },
+            Wrapper { val: U256::from(0) },
         );
         assert_eq!(
             serde_json::from_str::<Wrapper>("\"0x41\"").unwrap(),
-            Wrapper { val: 65.into() },
+            Wrapper {
+                val: U256::from(65)
+            },
         );
         assert_eq!(
             serde_json::from_str::<Wrapper>("\"0x400\"").unwrap(),
-            Wrapper { val: 1024.into() },
+            Wrapper {
+                val: U256::from(1024)
+            },
         );
         assert_eq!(
             serde_json::from_str::<Wrapper>(
@@ -124,7 +133,7 @@ mod test {
             )
             .unwrap(),
             Wrapper {
-                val: U256::max_value() - 1
+                val: U256::MAX - U256::from(1)
             },
         );
         assert_eq!(
@@ -132,9 +141,7 @@ mod test {
                 "\"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\""
             )
             .unwrap(),
-            Wrapper {
-                val: U256::max_value()
-            },
+            Wrapper { val: U256::MAX },
         );
         serde_json::from_str::<Wrapper>("\"0x\"").unwrap_err();
         serde_json::from_str::<Wrapper>("\"0x0400\"").unwrap_err();


### PR DESCRIPTION
This is a staging PR for the switch from `ethereum-types` to `alloy`.

The plan is to get this PR integrated with Lighthouse and passing all tests prior to merging.

SigP contributors are free to push to this PR, or raise further PRs against it.