### PR TITLE
Release v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum_serde_utils"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 description = "Serialization and deserialization utilities for JSON representations of Ethereum types"
 license = "Apache-2.0"


### PR DESCRIPTION
New release to move off `ethereum-types` and onto `alloy-primitives`.