### PR TITLE
Add bytes_16_hex module for fixed 16-byte hex conversion

### DIFF
--- a/src/fixed_bytes_hex.rs
+++ b/src/fixed_bytes_hex.rs
@@ -143,3 +143,7 @@ pub mod bytes_4_hex {
 pub mod bytes_8_hex {
     bytes_hex!(8);
 }
+
+pub mod bytes_16_hex {
+    bytes_hex!(16);
+}


### PR DESCRIPTION
This is useful as https://github.com/ethereum/execution-apis/pull/774/changes adds a fixed 16 byte API parameter. Even better would be a generic alternative to cover all cases, but that would be a breaking API change.